### PR TITLE
fix: 修复定时器在销毁时可能导致的崩溃问题

### DIFF
--- a/MQTTTests/MQTTTests.swift
+++ b/MQTTTests/MQTTTests.swift
@@ -1,0 +1,143 @@
+//
+//  MQTTTests.swift
+//  CocoaMQTT
+//
+//  Created by hujinyou on 2025/4/27.
+//
+
+import XCTest
+@testable import CocoaMQTT
+
+final class MQTTTests: XCTestCase {
+
+    class TimerWrapper {
+        var timer: CocoaMQTTTimer? = CocoaMQTTTimer(delay: 10, name: "crashTimer", timeInterval: 0)
+    }
+
+    func testDeinitWithoutResumeTriggersCrash() {
+        let expectation = self.expectation(description: "Timer should crash")
+
+        // 创建多个定时器，并用循环同时操作多个定时器
+        var timers: [CocoaMQTTTimer] = []
+        for i in 0..<10 {
+            let timer = CocoaMQTTTimer(name: "TestTimer\(i)", timeInterval: 0.1)
+
+            // 让定时器进入暂停状态
+            timer.suspend()
+
+            // 给定时器一个回调，并在回调中进行取消操作
+            timer.eventHandler = { [weak timer] in
+                guard let timer = timer else { return }
+                // 模拟多次暂停和取消定时器
+                if i % 2 == 0 {
+                    timer.suspend()
+                    timer.cancel()
+                    print("Timer \(i) suspended and cancelled")
+                } else {
+                    timer.resume()
+                    timer.cancel()
+                    print("Timer \(i) resumed and cancelled")
+                }
+            }
+
+            print("Timer \(i) created")
+            timers.append(timer)
+
+            // 手动触发定时器，使其开始工作
+            DispatchQueue.global().asyncAfter(deadline: .now() + Double(i) * 0.05) {
+                print("Timer \(i) started")
+                timer.resume()
+            }
+        }
+
+        // 等待一定的时间，让定时器操作完成
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            print("All timers should be cancelled")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+}
+
+
+final class CocoaMQTTTimerTests: XCTestCase {
+
+    /// 测试反复创建和销毁 Timer，验证是否会因 suspend 状态下 cancel 崩溃
+    func testRapidCreateAndDestroy() {
+        for i in 0..<1000 {
+            let timer = CocoaMQTTTimer(delay: 0.1, name: "timer-\(i)", timeInterval: 0)
+            timer.eventHandler = {
+                // no-op
+            }
+            // 不 resume，直接释放 -> 验证 deinit 能否避免 crash
+        }
+    }
+
+    /// 测试 Timer 在 resume 后销毁
+    func testResumeThenDeinit() {
+        for i in 0..<1000 {
+            let timer = CocoaMQTTTimer(delay: 0.1, name: "resume-\(i)", timeInterval: 0)
+            timer.eventHandler = { }
+            timer.resume()
+        }
+    }
+
+    /// 测试 Timer 在 resume -> suspend -> resume -> cancel 多次操作后释放
+    func testRepeatedResumeSuspendCancel() {
+        for i in 0..<1000 {
+            let timer = CocoaMQTTTimer(delay: 0.1, name: "bounce-\(i)", timeInterval: 1.0)
+            timer.eventHandler = { }
+
+            timer.resume()
+            timer.suspend()
+            timer.resume()
+            timer.cancel()
+        }
+    }
+
+    /// 验证 after 模式不会 crash，自动执行一次后释放
+    func testAfterExecutesSafely() {
+        let expectation = expectation(description: "after block executed")
+        let timer = CocoaMQTTTimer.after(0.5, name: "after-test") {
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(timer)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    /// 多线程并发创建/销毁 Timer，验证线程安全
+    func testConcurrentTimerLifecycle() {
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "test.concurrent.queue", attributes: .concurrent)
+
+        for i in 0..<1000 {
+            group.enter()
+            queue.async {
+                let timer = CocoaMQTTTimer(delay: 0.1, name: "concurrent-\(i)", timeInterval: 0.2)
+                timer.eventHandler = { }
+                timer.resume()
+                timer.suspend()
+                timer.cancel()
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success)
+    }
+
+    /// Timer 在 handler 内部立即 suspend 自己，确保不影响后续 deinit
+    func testSuspendInsideHandler() {
+        let expectation = expectation(description: "handler executed")
+        var timer: CocoaMQTTTimer? = CocoaMQTTTimer(name: "suspend-inside", timeInterval: 0.1)
+        timer?.eventHandler = {
+            timer?.suspend()
+            timer = nil
+            expectation.fulfill()
+        }
+        timer?.resume()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,19 +19,31 @@ let package = Package(
         .package(url: "https://github.com/leeway1208/MqttCocoaAsyncSocket", from: "1.0.8"),
     ],
     targets: [
-        .target(name: "CocoaMQTT",
-                dependencies: [ "MqttCocoaAsyncSocket" ],
-                path: "Source",
-                exclude: ["CocoaMQTTWebSocket.swift"],
-                swiftSettings: [ .define("IS_SWIFT_PACKAGE")]),
-        .target(name: "CocoaMQTTWebSocket",
-                dependencies: [ "CocoaMQTT", "Starscream" ],
-                path: "Source",
-                sources: ["CocoaMQTTWebSocket.swift"],
-                swiftSettings: [ .define("IS_SWIFT_PACKAGE")]),
-        .testTarget(name: "CocoaMQTTTests",
-                    dependencies: [ "CocoaMQTT", "CocoaMQTTWebSocket" ],
-                    path: "CocoaMQTTTests",
-                    swiftSettings: [ .define("IS_SWIFT_PACKAGE")])
+        .target(
+            name: "CocoaMQTT",
+            dependencies: [ "MqttCocoaAsyncSocket" ],
+            path: "Source",
+            exclude: ["CocoaMQTTWebSocket.swift"],
+            swiftSettings: [ .define("IS_SWIFT_PACKAGE")]
+        ),
+        .target(
+            name: "CocoaMQTTWebSocket",
+            dependencies: [ "CocoaMQTT", "Starscream" ],
+            path: "Source",
+            sources: ["CocoaMQTTWebSocket.swift"],
+            swiftSettings: [ .define("IS_SWIFT_PACKAGE")]
+        ),
+        .testTarget(
+            name: "CocoaMQTTTests",
+            dependencies: [ "CocoaMQTT", "CocoaMQTTWebSocket" ],
+            path: "CocoaMQTTTests",
+            swiftSettings: [ .define("IS_SWIFT_PACKAGE")]
+        ),
+        .testTarget(
+            name: "MQTTTests",
+            dependencies: ["CocoaMQTT"],
+            path: "MQTTTests",
+            swiftSettings: [ .define("IS_SWIFT_PACKAGE")]
+        )
     ]
 )

--- a/Source/CocoaMQTTTimer.swift
+++ b/Source/CocoaMQTTTimer.swift
@@ -9,102 +9,155 @@
 
 import Foundation
 
-// modeled after RepeatingTimer by Daniel Galasko: https://medium.com/@danielgalasko/a-background-repeating-timer-in-swift-412cecfd2ef9
-/// RepeatingTimer mimics the API of DispatchSourceTimer but in a way that prevents
-/// crashes that occur from calling resume multiple times on a timer that is
-/// already resumed (noted by https://github.com/SiftScience/sift-ios/issues/52)
-class CocoaMQTTTimer {
-    
+/// CocoaMQTT 内部使用的 GCD Timer 实现，避免重复 resume 或 suspend 导致的崩溃。
+/// 支持 `.after` 和 `.every` 两种使用方式，兼顾线程安全与状态管理。
+final class CocoaMQTTTimer {
+
+    /// 定时任务间隔
     let timeInterval: TimeInterval
+
+    /// 初次启动延迟时间
     let startDelay: TimeInterval
+
+    /// 当前 timer 的唯一名称（用于标识调试）
     let name: String
-    
-    init(delay:TimeInterval?=nil, name: String, timeInterval: TimeInterval) {
+
+    /// Timer 执行所在队列（串行，目标为共享并发队列）
+    private let queue: DispatchQueue
+
+    /// 具体使用的 GCD 定时器对象
+    private let timer: DispatchSourceTimer
+
+    /// 用户设置的回调事件
+    var eventHandler: (() -> Void)?
+
+    /// 定时器状态（避免重复 resume/cancel）
+    private enum State {
+        case suspended
+        case resumed
+        case canceled
+    }
+
+    /// 当前状态（默认 suspended）
+    private var state: State = .suspended
+
+    /// 用于同步状态访问的互斥锁
+    private let lock = NSLock()
+
+    /// 初始化定时器（不自动启动）
+    /// - Parameters:
+    ///   - delay: 初次启动延迟
+    ///   - name: timer 名称
+    ///   - timeInterval: 循环时间间隔（为 0 则只执行一次）
+    init(delay: TimeInterval? = nil, name: String, timeInterval: TimeInterval) {
         self.name = name
         self.timeInterval = timeInterval
-        if let delay = delay {
-            self.startDelay = delay
-        } else {
-            self.startDelay = timeInterval
+        self.startDelay = delay ?? timeInterval
+
+        // 使用串行队列执行任务，挂靠在 CocoaMQTT 的共享并发队列上
+        self.queue = DispatchQueue(label: "io.emqx.CocoaMQTT.\(name)", target: CocoaMQTTTimer.targetQueue)
+        self.timer = DispatchSource.makeTimerSource(flags: .strict, queue: self.queue)
+
+        // 配置定时器调度策略
+        self.timer.schedule(
+            deadline: .now() + self.startDelay,
+            repeating: self.timeInterval > 0 ? self.timeInterval : .infinity
+        )
+
+        // 设置回调逻辑
+        self.timer.setEventHandler { [weak self] in
+            self?.eventHandler?()
         }
     }
-    
+
+    /// 销毁时：确保事件清空 + 状态一致性 + 避免崩溃
+    deinit {
+        lock.lock()
+
+        // 清空回调，防止持有
+        timer.setEventHandler {}
+
+        // 防止崩溃：如果是 suspended 状态，必须 resume 后再 cancel
+        if state == .suspended {
+            timer.resume()
+        }
+
+        state = .canceled
+        timer.cancel()
+        eventHandler = nil
+
+        lock.unlock()
+    }
+
+    /// 开始执行定时任务（只能调用一次）
+    func resume() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard state == .suspended else { return }
+
+        state = .resumed
+        timer.resume()
+    }
+
+    /// 暂停定时任务
+    func suspend() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard state == .resumed else { return }
+
+        state = .suspended
+        timer.suspend()
+    }
+
+    /// 取消定时器
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard state != .canceled else { return }
+
+        if state == .suspended {
+            timer.resume() // 必须 resume 后才能 cancel
+        }
+
+        state = .canceled
+        timer.cancel()
+    }
+
+    /// CocoaMQTT 内部定时任务共享并发队列
+    private static let targetQueue = DispatchQueue(
+        label: "io.emqx.CocoaMQTT.TimerQueue",
+        qos: .default,
+        attributes: .concurrent
+    )
+
+    /// 快速创建一个循环执行的定时器
+    /// - Parameters:
+    ///   - interval: 间隔时间
+    ///   - name: 标识名称
+    ///   - block: 要执行的事件
     class func every(_ interval: TimeInterval, name: String, _ block: @escaping () -> Void) -> CocoaMQTTTimer {
         let timer = CocoaMQTTTimer(name: name, timeInterval: interval)
         timer.eventHandler = block
         timer.resume()
         return timer
     }
-    
+
+    /// 快速创建一个只执行一次的定时器
+    /// - Parameters:
+    ///   - interval: 延迟时间
+    ///   - name: 标识名称
+    ///   - block: 要执行的事件
     @discardableResult
     class func after(_ interval: TimeInterval, name: String, _ block: @escaping () -> Void) -> CocoaMQTTTimer {
-        let timer: CocoaMQTTTimer? = CocoaMQTTTimer(delay: interval, name: name, timeInterval: 0)
-        timer?.eventHandler = { [weak timer] in
+        let timer = CocoaMQTTTimer(delay: interval, name: name, timeInterval: 0)
+        timer.eventHandler = { [weak timer] in
             block()
             timer?.suspend()
-            timer = nil
         }
-        timer?.resume()
-        return timer!
-    }
-    
-    /// Execute the tasks concurrently on the target_queue with default QOS
-    private static let target_queue = DispatchQueue(label: "io.emqx.CocoaMQTT.TimerQueue", qos: .default, attributes: .concurrent)
-    
-    /// Execute each timer tasks serially and use the target queue for concurrency among timers
-    private lazy var timer: DispatchSourceTimer = {
-        let queue = DispatchQueue(label: "io.emqx.CocoaMQTT." + name, target: CocoaMQTTTimer.target_queue)
-        let t = DispatchSource.makeTimerSource(flags: .strict, queue: queue)
-        t.schedule(deadline: .now() + self.startDelay, repeating: self.timeInterval > 0 ? Double(self.timeInterval) : Double.infinity)
-        t.setEventHandler(handler: { [weak self] in
-            self?.eventHandler?()
-        })
-        return t
-    }()
-    
-    var eventHandler: (() -> Void)?
-    
-    private enum State {
-        case suspended
-        case resumed
-        case canceled
-    }
-    
-    private var state: State = .suspended
-    
-    deinit {
-        timer.setEventHandler {}
-        timer.cancel()
-        /*
-         If the timer is suspended, calling cancel without resuming
-         triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
-         */
-        resume()
-        eventHandler = nil
-    }
-    
-    func resume() {
-        if state == .resumed {
-            return
-        }
-        state = .resumed
         timer.resume()
-    }
-    
-    func suspend() {
-        if state == .suspended {
-            return
-        }
-        state = .suspended
-        timer.suspend()
-    }
-    
-    /// Manually cancel timer
-    func cancel() {
-        if state == .canceled {
-            return
-        }
-        state = .canceled
-        timer.cancel()
+        return timer
     }
 }


### PR DESCRIPTION
解决如下崩溃：
```
Thread 0 Crashed:
0   libdispatch.dylib             	0x000000019dac3dc4 _os_object_retain + 68
1   Tiger Trade                   	0x00000001020f4a50 CocoaMQTTTimer.timer.getter + 18139728 (<compiler-generated>:0)
2   Tiger Trade                   	0x00000001020f528c CocoaMQTTTimer.deinit + 18141836 (CocoaMQTTTimer.swift:77)
3   Tiger Trade                   	0x00000001020f5328 CocoaMQTTTimer.__deallocating_deinit + 18141992 (CocoaMQTTTimer.swift:0)
4   libswiftCore.dylib            	0x00000001aedf39f8 _swift_release_dealloc + 56
5   libswiftCore.dylib            	0x00000001aedf4a4c bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 160
6   Tiger Trade                   	0x00000001020ddb1c CocoaMQTT5.connect(timeout:) + 18045724 (CocoaMQTT5.swift:425)
7   Tiger Trade                   	0x00000001020c4fbc closure #1 in doConnectActionSafe #1 <A>() in TBMQTTProtocol.connectWith(username:password:userProperties:) + 17944508 (<compiler-generated>:0)
```

原有实现在单元测试的暴力测试下肯定会崩溃，经过解决后没有再出现崩溃。

```
    func testDeinitWithoutResumeTriggersCrash() {
        let expectation = self.expectation(description: "Timer should crash")

        // 创建多个定时器，并用循环同时操作多个定时器
        var timers: [CocoaMQTTTimer] = []
        for i in 0..<10 {
            let timer = CocoaMQTTTimer(name: "TestTimer\(i)", timeInterval: 0.1)

            // 让定时器进入暂停状态
            timer.suspend()

            // 给定时器一个回调，并在回调中进行取消操作
            timer.eventHandler = { [weak timer] in
                guard let timer = timer else { return }
                // 模拟多次暂停和取消定时器
                if i % 2 == 0 {
                    timer.suspend()
                    timer.cancel()
                    print("Timer \(i) suspended and cancelled")
                } else {
                    timer.resume()
                    timer.cancel()
                    print("Timer \(i) resumed and cancelled")
                }
            }

            print("Timer \(i) created")
            timers.append(timer)

            // 手动触发定时器，使其开始工作
            DispatchQueue.global().asyncAfter(deadline: .now() + Double(i) * 0.05) {
                print("Timer \(i) started")
                timer.resume()
            }
        }

        // 等待一定的时间，让定时器操作完成
        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
            print("All timers should be cancelled")
            expectation.fulfill()
        }

        wait(for: [expectation], timeout: 5)
    }
```